### PR TITLE
Solve potential broken Minecraft Java queries.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "gamedig"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065c3ffd16aa9d82d77004b2f65c064ef1b0b34392dd12f36b68eb425e9b671b"
+checksum = "b51d0400b1e960f3b1ecd331d9bf32d2169d00be0994a2843dc3e95b74f8bec5"
 dependencies = [
  "byteorder",
  "bzip2-rs",

--- a/minecraft_status/Cargo.toml
+++ b/minecraft_status/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 dotenvy = "0.15.7"
-gamedig = { version = "0.3.0", features = [ "serde" ] }
+gamedig = { version = "0.4.0", features = [ "serde" ] }
 anyhow = "1.0.75"
 parse_duration = "2.1.1"
 log = "0.4.20"

--- a/minecraft_status/src/main.rs
+++ b/minecraft_status/src/main.rs
@@ -8,8 +8,8 @@ use axum::response::Html;
 use axum::routing::get;
 use axum::Router;
 use config::Config;
-use gamedig::games::mc;
-use gamedig::protocols::minecraft::JavaResponse;
+use gamedig::games::minecraft;
+use gamedig::protocols::minecraft::{JavaResponse, RequestSettings};
 use log::{debug, info, warn, LevelFilter};
 use minijinja::render;
 use std::collections::HashMap;
@@ -95,10 +95,15 @@ fn get_port() -> u16 {
 
 /// Updates a status with result from given server
 fn update_status(status: &Status, server: &Server) {
+    let java_request_settings = RequestSettings {
+        hostname: server.server.clone(),
+        protocol_version: -1, // query for any minecraft java versions
+    };
+
     // get new status, trying java and then bedrock
-    let new_status = if let Ok(response) = mc::query_java(&server.ip, Some(server.port)) {
+    let new_status = if let Ok(response) = minecraft::query_java(&server.ip, Some(server.port), Some(java_request_settings)) {
         Some(response)
-    } else if let Ok(response) = mc::query_bedrock(&server.ip, Some(server.port)) {
+    } else if let Ok(response) = minecraft::query_bedrock(&server.ip, Some(server.port)) {
         Some(JavaResponse::from_bedrock_response(response))
     } else {
         None


### PR DESCRIPTION
This addresses the problem that I stated in #1, long story short, if the hostname is not in the query packet, some servers wont respond, and now that GameDig released a new version containing the required feature to do so, move to it.

~~This is a draft because it seems that Hypixel (the server where we found the problem) seem to have soft blocked me.~~ Confirmed with another server.

Edit: Also tried InsanityCraft, before: 
![image](https://github.com/aaronlindsay879/minecraft_status/assets/7972857/5490de8b-66aa-4a9a-aa54-2da97aa04906)
(this is because of tcpshield, in the gamedig package the title states to specify the hostname)
After specifying the hostname:
![image](https://github.com/aaronlindsay879/minecraft_status/assets/7972857/725a297f-f9f8-411c-968b-ab9ae4763033)
